### PR TITLE
refactor(testnet): update testnet claim message prefix to tZENCLAIM

### DIFF
--- a/app/components/organisms/SigningToolWithPrivateKey.tsx
+++ b/app/components/organisms/SigningToolWithPrivateKey.tsx
@@ -42,7 +42,7 @@ function SigningToolWithPrivateKey({transport}: any) {
 
   const { destinationAddress, derivationPathAccount, derivationPathChange, derivationPathIndex} = form.watch();
   // const MESSAGE_TO_SIGN = useMemo(() => "ZENCLAIM" + destinationAddress, [destinationAddress]);
-  const MESSAGE_TO_SIGN = useMemo(() => "ZT3CLAIM" + destinationAddress, [destinationAddress]);
+  const MESSAGE_TO_SIGN = useMemo(() => "tZENCLAIM" + destinationAddress, [destinationAddress]);
 
   const btc = useRef<Btc | null>(null);;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ledger-signing-tool",
-  "version": "1.0.0-ZT3CLAIM",
+  "version": "1.0.0-tZENCLAIM",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ledger-signing-tool",
-      "version": "1.0.0-ZT3CLAIM",
+      "version": "1.0.0-tZENCLAIM",
       "dependencies": {
         "@hookform/resolvers": "3.10.0",
         "@ledgerhq/device-management-kit": "0.0.0-20250120001116",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledger-signing-tool",
-  "version": "1.0.0-ZT3CLAIM",
+  "version": "1.0.0-tZENCLAIM",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Update signing message prefix to tZENCLAIM

Updates the message prefix used in the Ledger signing tool to match the testnet prefix format, ensuring consistency across the application.

## Changes

- Changed message prefix from ZT3CLAIM to tZENCLAIM in SigningToolWithPrivateKey component
- Updated version string in package.json from 1.0.0-ZT3CLAIM to 1.0.0-tZENCLAIM
- Updated version string in package-lock.json to match package.json